### PR TITLE
doc: add additional example, fix typo, be slightly more explicit in 'Quick tour'

### DIFF
--- a/try.go
+++ b/try.go
@@ -70,11 +70,12 @@
 //		return nil
 //	}
 //
-// # Quick tour of the API
+// Quick tour of the API
 //
 // The E family of functions all remove a final error return, panicking if non-nil.
 //
-// Handle allows easy assignment of that error to a return error value.
+// Handle recovers from that panic and allows assignment of the error to a return
+// error value. Other panics are not recovered.
 //
 //	func f() (err error) {
 //		defer try.Handle(&err)
@@ -83,16 +84,23 @@
 //
 // HandleF is like Handle, but it calls a function after any such assignment.
 //
-//	 func f() (err error) {
+//	func f() (err error) {
 //		defer try.HandleF(&err, func() {
 //			if err == io.EOF {
 //				err = io.ErrUnexpectedEOF
 //			}
 //		})
-//	 	...
-//	 }
+//		...
+//	}
 //
-// F wraps an error with file and line formation and calls a function on error.
+//	func foo(i int) (err error) {
+//		defer try.HandleF(&err, func() {
+//			err = fmt.Errorf("unable to foo %d: %w", i, err)
+//		})
+//		...
+//	}
+//
+// F wraps an error with file and line information and calls a function on error.
 // It inter-operates well with testing.TB and log.Fatal.
 //
 //	func TestFoo(t *testing.T) {


### PR DESCRIPTION
Feel free to tweak or reject any or all of this.

* Typo: 'formation'.
* Added a simple error wrapping example.
* pkg.go.dev doesn't (yet!) support the new 1.19 go doc header syntax... although maybe the `#` was deliberate?
* Probably most debatable: 
  * In my first quick skim, I didn't immediately pick up that Handle recovers the panic, and that it is targeted in doing so (perhaps in part because my brain was seeded by the first check/handle proposal where `handle` was not needed to avoid a panic). 
  * I tried to make that more obvious in the 'Quick tour' section to help people more easily pick up the gist of the overall package. 
  * This is covered in the function doc comments, though, so perhaps not worthwhile.

